### PR TITLE
Subtyping relation is defined only over records (close #3)

### DIFF
--- a/Data/Vinyl/Relation.hs
+++ b/Data/Vinyl/Relation.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -18,18 +20,38 @@ import Data.Vinyl.Field
 import Data.Vinyl.Rec
 import Data.Vinyl.Lens
 
+import GHC.Prim (Constraint)
+
 -- A subtyping relation
-class ss <: ts where
-  cast :: Rec ss -> Rec ts
+class (IsSubtype r1 r2) => r1 <: r2 where
+  cast :: r1 -> r2
+
+-- On record is a subtype of another if the fields of the latter are a
+-- subset of the fields of the former.
+type family IsSubtype r1 r2 :: Constraint
+type instance IsSubtype (Rec ss) (Rec ts) = Implicit (Subset ts ss)
+
+data Subset :: [k] -> [k] -> * where
+  SubsetNil  :: Subset '[] xs
+  SubsetCons ::
+    Elem x ys ->
+    Subset xs ys ->
+    Subset (x ': xs) ys
+
+instance Implicit (Subset '[] xs) where
+  implicitly = SubsetNil
+instance (IElem x ys, Implicit (Subset xs ys)) => Implicit (Subset (x ': xs) ys) where
+  implicitly = SubsetCons implicitly implicitly
+
 
 -- If two records types are subtypes of each other, that means that they
 -- differ only in order of fields.
 type ss :~: ts = (ss <: ts, ts <: ss)
 
-instance xs <: '[] where
+instance Rec xs <: (Rec '[]) where
   cast _ = RNil
 
-instance (y ~ (sy ::: t), IElem y xs, xs <: ys) => xs <: (y ': ys) where
+instance (y ~ (sy ::: t), IElem y xs, Rec xs <: Rec ys) => Rec xs <: Rec (y ': ys) where
   cast r = (field, rGet field r) :& cast r
     where field = lookupField implicitly r
 
@@ -37,7 +59,6 @@ lookupField :: Elem x xs -> Rec xs -> x
 lookupField Here ((k,_) :& _) = k
 lookupField (There p) (_ :& xs) = lookupField p xs
 
-rIso :: (fs1 :~: fs2) => SimpleIso (Rec fs1) (Rec fs2)
+rIso :: (r1 :~: r2) => SimpleIso r1 r2
 rIso = iso cast cast
-
 


### PR DESCRIPTION
The subtyping relation `(<:)` now takes as its arguments two record types (rather than lists of fields). This makes it easier to express desired constraints in real code, since the following is now allowed:

``` haskell
type Dog = Rec ["name" ::: String, "age" ::: Int]
blorg :: (r <: Dog) => r -> (String,Int)
blorg = (,) <$> rGet name <*> rGet age
```

By requiring real witnesses of the subtyping relation (that is, a witness that the fields of the subtype are a superset of the fields of the supertype), we also gain for free the advantage of `(<:)` being a closed class: it is a type error for it to be defined for anything other than records.

This is because the `IsSubtype` constraint family is only defined over records, and it is not exported (so nobody can create any further instances).
