### PR TITLE
7.6.2 compatibility.

### DIFF
--- a/Data/Vinyl/Lens.hs
+++ b/Data/Vinyl/Lens.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}


### PR DESCRIPTION
7.6.2 seems to require a DataKinds pragma in Data/Vinyl/Lens.hs. This compiles on both 7.6.1 and 7.6.2.
