### PR TITLE
Loosens the record type on `<:` from PlainRec to Rec

### DIFF
--- a/Data/Vinyl/Relation.hs
+++ b/Data/Vinyl/Relation.hs
@@ -45,8 +45,8 @@ x ~= y = x == (cast y)
 instance Rec xs f <: Rec '[] f where
   cast _ = RNil
 
-instance (y ~ (sy ::: t), IElem y xs, PlainRec xs <: PlainRec ys) => PlainRec xs <: PlainRec (y ': ys) where
-  cast r = Identity (rGet field r) :& cast r
+instance (y ~ (sy ::: t), IElem y xs, Rec xs f <: Rec ys f) => Rec xs f <: Rec (y ': ys) f where
+  cast r = (r^.(rLens' field)) :& cast r
     where field = lookupField (implicitly :: Elem y xs) r
 
 lookupField :: Elem x xs -> Rec xs f -> x


### PR DESCRIPTION
This lets you use `cast` on records that are not built with the Identity functor. My use case was refining something like the validator example from the tutorial:

```
type Aged = "age" :: Int ': '[]

ageValidator :: Rec Age (Validator [String])
ageValidator = cast vperson
```

I'm not sure if this affects type inference, I found I've had to be pretty liberal in my type annotations when using cast.
