### PR TITLE
Folding across a homogenous record

### DIFF
--- a/Data/Vinyl/Classes.hs
+++ b/Data/Vinyl/Classes.hs
@@ -18,6 +18,10 @@ class Apply (arr :: k -> k -> k) (f :: k -> *) where
 class Run t where
   run :: Applicative f => t f -> f (t Identity)
 
+-- | If a record is homogenous, you can fold over it.
+class FoldRec r a where
+  foldRec :: (a -> b -> b) -> b -> r -> b
+
 -- | '(~>)' is a morphism between functors.
 newtype (f ~> g) x = NT { runNT :: f x -> g x }
 

--- a/Data/Vinyl/Rec.hs
+++ b/Data/Vinyl/Rec.hs
@@ -82,6 +82,16 @@ instance Run (Rec rs) where
   run RNil      = pure RNil
   run (x :& xs) = (:&) <$> (pure <$> x) <*> run xs
 
+instance FoldRec (Rec '[] f) a where
+  foldRec _ z RNil = z
+
+instance FoldRec (Rec fs g) (g t) => FoldRec (Rec ((s ::: t) ': fs) g) (g t) where
+  foldRec f z (x :& xs) = f x (foldRec f z xs)
+
+-- | Accumulates a homogenous record into a list
+recToList :: FoldRec (Rec fs g) (g t) => Rec fs g -> [g t]
+recToList = foldRec (\e a -> [e] ++ a) []
+
 -- | We provide a 'Show' instance for 'Identity'.
 instance Show a => Show (Identity a) where
   show (Identity x) = show x


### PR DESCRIPTION
It needs some type annotating to make it all work (on account of the second FoldRec type parameter). But it's pretty cool:

```
> let rec = fixRecord $ (Field :: "a" ::: Int) =: 5 <+> (Field :: "b" ::: Int) =: 6

> foldRec (liftA2 (+)) (pure 0) rec :: Identity Int
11
> recToList rec :: [Identity Int]
[5,6]
```

In crafting these examples, I've realised there's probably uses in an API that accounts for the Functor but this works for what I wanted :)
