### PR TITLE
SingI has been dropped from GHC 7.8

### DIFF
--- a/Data/Vinyl/Field.hs
+++ b/Data/Vinyl/Field.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
@@ -7,11 +8,19 @@
 
 module Data.Vinyl.Field where
 
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
+import           Data.Proxy
+#endif
 import           GHC.TypeLits
 
 -- | A field contains a key and a type.
 data (:::) :: Symbol -> * -> * where
   Field :: sy ::: t
 
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
+instance KnownSymbol sy => Show (sy ::: t) where
+  show Field = symbolVal (Proxy :: Proxy sy)
+#else
 instance SingI sy => Show (sy ::: t) where
   show Field = fromSing (sing :: Sing sy)
+#endif

--- a/Data/Vinyl/Rec.hs
+++ b/Data/Vinyl/Rec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns              #-}
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE FlexibleContexts          #-}
@@ -65,7 +66,13 @@ type instance (a ': as) ++ bs  = a ': (as ++ bs)
 
 instance Show (Rec '[] f) where
   show RNil = "{}"
-instance (SingI sy, Show (g t), Show (Rec fs g)) => Show (Rec ((sy ::: t) ': fs) g) where
+instance (
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
+    KnownSymbol sy,
+#else
+    SingI sy,
+#endif
+    Show (g t), Show (Rec fs g)) => Show (Rec ((sy ::: t) ': fs) g) where
   show (x :& xs) = show (Field :: sy ::: t) ++ " :=: " ++ show x ++ ", " ++ show xs
 
 

--- a/vinyl.cabal
+++ b/vinyl.cabal
@@ -23,7 +23,7 @@ library
                        Data.Vinyl.Witnesses, Data.Vinyl.Rec,
                        Data.Vinyl.Relation, Data.Vinyl.Unicode,
                        Data.Vinyl.Classes, Data.Vinyl.Validation
-  build-depends:       base ==4.6.*, lens >=3.8, ghc-prim, mtl
+  build-depends:       base >=4.6, lens >=3.8, ghc-prim, mtl
   default-language:    Haskell2010
 
 benchmark bench-builder-all


### PR DESCRIPTION
The new TypeLits module no longer defines `SingI`, it's been replaced by `KnownNat` and `KnownSym`. I'm not a big fan of CPP hacks but I imagine it's better to continue supporting 7.6 for a while.
