### PR TITLE
Use closed type families where possible

### DIFF
--- a/Data/Vinyl/Constraint.hs
+++ b/Data/Vinyl/Constraint.hs
@@ -44,7 +44,7 @@ type r1 :~: r2 = (r1 <: r2, r2 <: r1)
 (~=) :: (Eq (Rec el f xs), xs :~: ys) => Rec el f xs -> Rec el f ys -> Bool
 x ~= y = x == (cast y)
 
-type family RecAll (el :: TyFun k l -> *) (f :: * -> *) (rs :: [k]) (c :: * -> Constraint) :: Constraint
-type instance RecAll el f '[] c = ()
-type instance RecAll el f (r ': rs) c = (c (f (el $ r)), RecAll el f rs c)
+type family RecAll (el :: TyFun k l -> *) (f :: * -> *) (rs :: [k]) (c :: * -> Constraint) :: Constraint where
+  RecAll el f '[] c = ()
+  RecAll el f (r ': rs) c = (c (f (el $ r)), RecAll el f rs c)
 

--- a/Data/Vinyl/Operators.hs
+++ b/Data/Vinyl/Operators.hs
@@ -44,9 +44,9 @@ RNil      <+> xs = xs
 infixr 5  <+>
 
 -- | Append for type-level lists.
-type family (as :: [k]) ++ (bs :: [k]) :: [k]
-type instance '[] ++ bs = bs
-type instance (a ': as) ++ bs  = a ': (as ++ bs)
+type family (as :: [k]) ++ (bs :: [k]) :: [k] where
+  '[] ++ bs = bs
+  (a ': as) ++ bs  = a ': (as ++ bs)
 
 (<<$>>) :: (forall x. f x -> g x) -> Rec el f rs -> Rec el g rs
 _   <<$>> RNil    = RNil


### PR DESCRIPTION
This would entail dropping support for GHC 7.6. Closed type families are more elegant, but do they actually buy us anything in these cases? If they do, I think we should do it, but if it's just aesthetic, we shouldn't.
