### PR TITLE
Extend ElField to make it more useful

### DIFF
--- a/Data/Vinyl/Derived.hs
+++ b/Data/Vinyl/Derived.hs
@@ -37,11 +37,14 @@ deriving instance Eq t => Eq (ElField '(s,t))
 deriving instance Ord t => Ord (ElField '(s,t))
 
 instance Show t => Show (ElField '(s,t)) where
-  show (Field x) = (symbolVal (Proxy::Proxy s))++" :-> "++show x
+  show (Field x) = symbolVal (Proxy::Proxy s) ++" :-> "++show x
 
 -- | Get the data payload of an 'ElField'.
 getField :: ElField '(s,t) -> t
 getField (Field x) = x
+
+getLabel :: forall s t. ElField '(s,t) -> String
+getLabel (Field x) = symbolVal (Proxy::Proxy s)
 
 -- | 'ElField' is isomorphic to a functor something like @Compose
 -- ElField ('(,) s)@.


### PR DESCRIPTION
This patch adds functionality for the user to query/modify a `FieldRec` by type level string labels directly, and also makes use of the latest feature in GHC 8.0, i.e., `OverloadedLabels`. So one can now do

```haskell
>>> :set -XFlexibleContexts -XOverloadedLabels
>>> let rec = (#label =: 3) :& (#another_label =: "great") :& RNil
>>> rgetf #label rec
label :-> 3
```
With a new type alias `:::`, it's now also easier to defiine big field records, e.g.,

```haskell
type Config = '[ "config_path" ::: FilePath
               , "username"    ::: String
               , "password"    ::: String
               ...
               ]
type ConfigRec = FieldRec Config
```

There are other nifty things you can do with a `FieldRec`, for example, I added a `AllFields` class, which allows to pass proofs that apply to all the rows of the record i.e., all of them being Fields and having `Symbol` kind labels, to variants of `rmap` and `rpure` a.k.a. `rmapf` and `rpuref`. With this I can get all the labels of the `FieldRec` in a `Rec (Const String) Fields`. (I tried to also allow dynamic constraint to be passed into `rmapf` and `rpuref` but that didn't go anywhere).

Note: in my change I've remapped `=:` to constructing individual fields, as the old functionality of creating a singleton record doesn't seem that useful to me. That function is now mapped to use `=:=` instead.

Other TODOs:

- add `rlensf` that can set and get field by label
- move `ElField` to a new module, maybe? 