### PR TITLE
Prevent bad build plans on GHC 7.10 and 7.8

### DIFF
--- a/vinyl.cabal
+++ b/vinyl.cabal
@@ -38,6 +38,7 @@ library
                        array
   default-language:    Haskell2010
   ghc-options: -fwarn-dodgy-exports -fwarn-dodgy-imports -fwarn-unused-matches -fwarn-unused-imports -fwarn-unused-binds -fwarn-incomplete-record-updates -fwarn-missing-signatures -fwarn-name-shadowing -fwarn-orphans -fwarn-overlapping-patterns -fwarn-tabs -fwarn-type-defaults
+  other-extensions:    TypeApplications
 
 benchmark storable
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
Telling cabal that we use TypeApplications lets it avoid a bad
build plan on GHC < 8