### PR TITLE
Exposing/Exporting Data.Vinyl.Recursive

### DIFF
--- a/vinyl.cabal
+++ b/vinyl.cabal
@@ -33,6 +33,7 @@ library
                      , Data.Vinyl.TypeLevel
                      , Data.Vinyl.Functor
                      , Data.Vinyl.Notation
+                     , Data.Vinyl.Recursive
                      , Data.Vinyl.SRec
                      , Data.Vinyl.Syntax
                      , Data.Vinyl.Tutorial.Overview


### PR DESCRIPTION
Thanks for the great package!  Just submitting this PR because the CHANGELOG and documentation seem to suggest that *Data.Vinyl.Recursive* is meant to be an exposed module, but I noticed that it wasn't listed in the cabal file.  This is a small patch exposing the module.

Feel free to close if this module is instead intended to be internal/hidden!