### PR TITLE
Implement record functor / field functor sequencing and joining

### DIFF
--- a/Data/Vinyl/TypeLevel.hs
+++ b/Data/Vinyl/TypeLevel.hs
@@ -115,3 +115,8 @@ type family ApplyToField (t :: Type -> Type) (a :: k1) = (r :: k1) | r -> t a wh
 type family MapTyCon t xs = r | r -> xs where
   MapTyCon t '[] = '[]
   MapTyCon t (x ': xs) = ApplyToField t x ': MapTyCon t xs
+
+-- | Remove a type constructor from each element of a type level list
+type family MapTyDeCon t xs where
+  MapTyDeCon t '[] = '[]
+  MapTyDeCon t ((t x) ': xs) = x ': MapTyDeCon t xs


### PR DESCRIPTION
These help implement unnesting for list records. 

I'm not completely
happy with the MapTypeDeCon family in that it isn't applicable to
symbol paired fields. I couldn't get the reverse equivalent of
ApplyToField to work with the injectivity annotation.

Also not sure if join is the right term here. Really it's about swapping
applicative implementations for `pure` and `liftA2`.