### PR TITLE
Fix building on GHC 8.8

### DIFF
--- a/Data/Vinyl/Class/Method.hs
+++ b/Data/Vinyl/Class/Method.hs
@@ -160,8 +160,8 @@ type family PayloadType f (a :: u) :: * where
 
 -- | Generate a record from fields derived from type class
 -- instances.
-class RecPointed c (f :: u -> *) (ts :: [u]) where
-  rpointMethod :: (forall (a :: u). c (f a) => f a) -> Rec f ts
+class RecPointed c f ts where
+  rpointMethod :: (forall a. c (f a) => f a) -> Rec f ts
 
 instance RecPointed c f '[] where
   rpointMethod _ = RNil
@@ -175,14 +175,14 @@ instance (c (f t), RecPointed c f ts)
 -- | Apply a typeclass method to each field of a 'Rec' where the class
 -- constrains the index of the field, but not its interpretation
 -- functor.
-class RecMapMethod c (f :: u -> *) (ts :: [u]) where
+class RecMapMethod c f ts where
   rmapMethod :: (forall a. c (PayloadType f a) => f a -> g a)
              -> Rec f ts -> Rec g ts
 
 -- | Apply a typeclass method to each field of a 'Rec' where the class
 -- constrains the field when considered as a value interpreted by the
 -- record's interpretation functor.
-class RecMapMethod1 c (f :: u -> *) (ts :: [u])where
+class RecMapMethod1 c f ts where
   rmapMethod1 :: (forall a. c (f a) => f a -> g a)
               -> Rec f ts -> Rec g ts
 

--- a/Data/Vinyl/FromTuple.hs
+++ b/Data/Vinyl/FromTuple.hs
@@ -51,7 +51,7 @@ type family UncurriedXRec (t :: (u -> *, [u])) = r | r -> t where
   UncurriedXRec '(f, ts) = XRec f ts
 
 -- | Convert between an 'XRec' and an isomorphic tuple.
-class TupleXRec (f :: u -> *) (t :: [u]) where
+class TupleXRec f t where
   -- | Convert an 'XRec' to a tuple. Useful for pattern matching on an
   -- entire record.
   xrecTuple :: XRec f t -> ListToHKDTuple f t

--- a/Data/Vinyl/Lens.hs
+++ b/Data/Vinyl/Lens.hs
@@ -139,7 +139,7 @@ rlens = rlensC
 -- record to the former's is evident. That is, we can either cast a larger
 -- record to a smaller one, or we may replace the values in a slice of a
 -- record.
-class is ~ RImage rs ss => RecSubset record (rs :: [k]) (ss :: [k]) is where
+class is ~ RImage rs ss => RecSubset record rs ss is where
   -- | An opportunity for instances to generate constraints based on
   -- the functor parameter of records passed to class methods.
   type RecSubsetFCtx record (f :: k -> *) :: Constraint

--- a/Data/Vinyl/Lens.hs
+++ b/Data/Vinyl/Lens.hs
@@ -38,9 +38,7 @@ import Data.Vinyl.TypeLevel
 -- the constraint solver realize that this is a decidable predicate
 -- with respect to the judgemental equality in @k@.
 class (i ~ RIndex r rs, NatToInt i)
-  => RecElem record (r :: k) (r' :: k)
-             (rs :: [k]) (rs' :: [k])
-             (i :: Nat) | r r' rs i -> rs' where
+  => RecElem record r r' rs rs' (i :: Nat) | r r' rs i -> rs' where
   -- | An opportunity for instances to generate constraints based on
   -- the functor parameter of records passed to class methods.
   type RecElemFCtx record (f :: k -> *) :: Constraint

--- a/Data/Vinyl/XRec.hs
+++ b/Data/Vinyl/XRec.hs
@@ -81,8 +81,8 @@ newtype XData t a = XData { unX :: HKD t a }
 -- permit unrolling of the recursion across a record. The function
 -- mapped across the vector hides the 'HKD' type family under a newtype
 -- constructor to help the type checker.
-class XRMap (f :: u -> *) (g :: u -> *) (rs :: [u]) where
-  xrmapAux :: (forall (a :: u) . XData f a -> XData g a) -> XRec f rs -> XRec g rs
+class XRMap f g rs where
+  xrmapAux :: (forall a . XData f a -> XData g a) -> XRec f rs -> XRec g rs
 
 instance XRMap f g '[] where
   xrmapAux _ RNil = RNil
@@ -127,7 +127,7 @@ instance (IsoXRec f ts, IsoHKD f t) => IsoXRec f (t ': ts) where
 -- This involves the so-called /higher-kinded data/ type family. See
 -- <http://reasonablypolymorphic.com/blog/higher-kinded-data> for more
 -- discussion.
-class IsoHKD (f :: u -> *) (a :: u) where
+class IsoHKD f a where
   type HKD f a
   type HKD f a = f a
   unHKD :: HKD f a -> f a


### PR DESCRIPTION
GHC 8.8 changes the way that kinds are quantified with respect to -XTypeApplications.  Now, for a typeclass like

```
class MyClass (f :: k -> *) a  where
  myMethod :: f a
```

`myMethod` will now expect `k` as an argument with TypeApplications, `myMethod @k @f @a`, even if it isn't explicitly listed as a parameter of the typeclass.

Because of this, a lot of internal code will no longer work because many typeclasses mention a kind variable without explicitly bringing it as a TC parameter.  This also changes the external API in a fundamental way.

There are two ways to fix this, I think:

1. Keep the typeclasses the way they are -- their external API's will now be different between 8.6 and 8.8, and we have to use CPP on type applications or clever type annotations to make code backwards  compatible
2. Change the typeclass definitions to no longer explicitly mention `k`.  This preserves the external API, and is backwards compatible from an external sense, at the cost of documentation being a little less clear.

This PR implements the second way.  Let me know if there's anything I can add, or if you decide to go down another route :)