### PR TITLE
Split out rcurry and rcurry' into different typeclasses

### DIFF
--- a/Data/Vinyl/Curry.hs
+++ b/Data/Vinyl/Curry.hs
@@ -33,6 +33,7 @@ class RecordCurry ts where
   -}
   rcurry :: (Rec f ts -> a) -> CurriedF f ts a
 
+class RecordCurry' ts where
   {-|
   N-ary version of 'curry' over pure records.
 
@@ -51,12 +52,14 @@ class RecordCurry ts where
 instance RecordCurry '[] where
   rcurry f = f RNil
   {-# INLINABLE rcurry #-}
+instance RecordCurry' '[] where
   rcurry' f = f RNil
   {-# INLINABLE rcurry' #-}
 
 instance RecordCurry ts => RecordCurry (t ': ts) where
   rcurry f x = rcurry (\xs -> f (x :& xs))
   {-# INLINABLE rcurry #-}
+instance RecordCurry' ts => RecordCurry' (t ': ts) where
   rcurry' f x = rcurry' (\xs -> f (Identity x :& xs))
   {-# INLINABLE rcurry' #-}
 


### PR DESCRIPTION
In the previous version, `rcurry` and `rcurry'` were mixed into a single typeclass.  The unfortunate consequence is that `rcurry` can no longer be poly-kinded in the type of its list items, since being able to implement `rcurry'` requires `ts :: [Type]`.

This change will allow a poly-kinded `rcurry` that can take lists with items of any kind.