### PR TITLE
Add a safe wrapper around ARec

### DIFF
--- a/Data/Vinyl/ARec.hs
+++ b/Data/Vinyl/ARec.hs
@@ -15,5 +15,7 @@ module Data.Vinyl.ARec
   , alens
   , arecGetSubset
   , arecSetSubset
+  , arecRepsMatchCoercion
+  , arecConsMatchCoercion
   ) where
 import Data.Vinyl.ARec.Internal

--- a/Data/Vinyl/ARec.hs
+++ b/Data/Vinyl/ARec.hs
@@ -1,133 +1,19 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE Trustworthy #-}
+
 -- | Constant-time field accessors for extensible records. The
 -- trade-off is the usual lists vs arrays one: it is fast to add an
 -- element to the head of a list, but element access is linear time;
 -- array access time is uniform, but extending the array is more
 -- slower.
-module Data.Vinyl.ARec where
-import Data.Vinyl.Core
-import Data.Vinyl.Lens (RecElem(..), RecSubset(..))
-import Data.Vinyl.TypeLevel
-
-import qualified Data.Array as Array
-import qualified Data.Array.Base as BArray
-import GHC.Exts (Any)
-import Unsafe.Coerce
-
--- | An array-backed extensible record with constant-time field
--- access.
-newtype ARec (f :: k -> *) (ts :: [k]) = ARec (Array.Array Int Any)
-
--- | Convert a 'Rec' into an 'ARec' for constant-time field access.
-toARec :: forall f ts. (NatToInt (RLength ts)) => Rec f ts -> ARec f ts
-toARec = go id
-  where go :: ([Any] -> [Any]) -> Rec f ts' -> ARec f ts
-        go acc RNil = ARec $! Array.listArray (0, n - 1) (acc [])
-        go acc (x :& xs) = go (acc . (unsafeCoerce x :)) xs
-        n = natToInt @(RLength ts)
-{-# INLINE toARec #-}
-
--- | Defines a constraint that lets us index into an 'ARec' in order
--- to produce a 'Rec' using 'fromARec'.
-class (NatToInt (RIndex t ts)) => IndexableField ts t where
-instance (NatToInt (RIndex t ts)) => IndexableField ts t where
-
--- | Convert an 'ARec' into a 'Rec'.
-fromARec :: forall f ts.
-            (RecApplicative ts, RPureConstrained (IndexableField ts) ts)
-         => ARec f ts -> Rec f ts
-fromARec (ARec arr) = rpureConstrained @(IndexableField ts) aux
-  where aux :: forall t. NatToInt (RIndex t ts) => f t
-        aux = unsafeCoerce (arr Array.! natToInt @(RIndex t ts))
-{-# INLINE fromARec #-}
-
--- | Get a field from an 'ARec'.
-aget :: forall t f ts. (NatToInt (RIndex t ts)) => ARec f ts -> f t
-aget (ARec arr) =
-  unsafeCoerce (BArray.unsafeAt arr (natToInt @(RIndex t ts)))
-{-# INLINE aget #-}
-
--- | Set a field in an 'ARec'.
-aput :: forall t t' f ts ts'. (NatToInt (RIndex t ts))
-      => f t' -> ARec f ts -> ARec f ts'
-aput x (ARec arr) = ARec (arr Array.// [(i, unsafeCoerce x)])
-  where i = natToInt @(RIndex t ts)
-{-# INLINE aput #-}
-
--- | Define a lens for a field of an 'ARec'.
-alens :: forall f g t t' ts ts'. (Functor g, NatToInt (RIndex t ts))
-      => (f t -> g (f t')) -> ARec f ts -> g (ARec f ts')
-alens f ar = fmap (flip (aput @t) ar) (f (aget ar))
-{-# INLINE alens #-}
-
--- instance (i ~ RIndex t ts, i ~ RIndex t' ts', NatToInt (RIndex t ts)) => RecElem ARec t t' ts ts' i where
---   rlens = alens
---   rget = aget
---   rput = aput
-
-instance RecElem ARec t t' (t ': ts) (t' ': ts) 'Z where
-  rlensC = alens
-  {-# INLINE rlensC #-}
-  rgetC = aget
-  {-# INLINE rgetC #-}
-  rputC = aput @t
-  {-# INLINE rputC #-}
-
-instance (RIndex t (s ': ts) ~ 'S i, NatToInt i,  RecElem ARec t t' ts ts' i)
-  => RecElem ARec t t' (s ': ts) (s ': ts') ('S i) where
-  rlensC = alens
-  {-# INLINE rlensC #-}
-  rgetC = aget
-  {-# INLINE rgetC #-}
-  rputC = aput @t
-  {-# INLINE rputC #-}
-
--- | Get a subset of a record's fields.
-arecGetSubset :: forall rs ss f.
-                 (IndexWitnesses (RImage rs ss), NatToInt (RLength rs))
-              => ARec f ss -> ARec f rs
-arecGetSubset (ARec arr) = ARec (Array.listArray (0, n-1) $
-                                 go (indexWitnesses @(RImage rs ss)))
-  where go :: [Int] -> [Any]
-        go = map (arr Array.!)
-        n = natToInt @(RLength rs)
-{-# INLINE arecGetSubset #-}
-
--- | Set a subset of a larger record's fields to all of the fields of
--- a smaller record.
-arecSetSubset :: forall rs ss f. (IndexWitnesses (RImage rs ss))
-              => ARec f ss -> ARec f rs -> ARec f ss
-arecSetSubset (ARec arrBig) (ARec arrSmall) = ARec (arrBig Array.// updates)
-  where updates = zip (indexWitnesses @(RImage rs ss)) (Array.elems arrSmall)
-{-# INLINE arecSetSubset #-}
-
-instance (is ~ RImage rs ss, IndexWitnesses is, NatToInt (RLength rs))
-         => RecSubset ARec rs ss is where
-  rsubsetC f big = fmap (arecSetSubset big) (f (arecGetSubset big))
-  {-# INLINE rsubsetC #-}
-
-instance (RPureConstrained (IndexableField rs) rs,
-          RecApplicative rs,
-          Show (Rec f rs)) => Show (ARec f rs) where
-  show = show . fromARec
-
-instance (RPureConstrained (IndexableField rs) rs,
-          RecApplicative rs,
-          Eq (Rec f rs)) => Eq (ARec f rs) where
-  x == y = fromARec x == fromARec y
-
-instance (RPureConstrained (IndexableField rs) rs,
-          RecApplicative rs,
-          Ord (Rec f rs)) => Ord (ARec f rs) where
-  compare x y = compare (fromARec x) (fromARec y)
+module Data.Vinyl.ARec
+  ( ARec -- Exported abstractly
+  , IndexableField
+  , toARec
+  , fromARec
+  , aget
+  , aput
+  , alens
+  , arecGetSubset
+  , arecSetSubset
+  ) where
+import Data.Vinyl.ARec.Internal

--- a/Data/Vinyl/ARec/Internal.hs
+++ b/Data/Vinyl/ARec/Internal.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- | Constant-time field accessors for extensible records. The
+-- trade-off is the usual lists vs arrays one: it is fast to add an
+-- element to the head of a list, but element access is linear time;
+-- array access time is uniform, but extending the array is more
+-- slower.
+module Data.Vinyl.ARec.Internal
+  ( ARec (..)
+  , IndexableField
+  , toARec
+  , fromARec
+  , aget
+  , aput
+  , alens
+  , arecGetSubset
+  , arecSetSubset
+  ) where
+import Data.Vinyl.Core
+import Data.Vinyl.Lens (RecElem(..), RecSubset(..))
+import Data.Vinyl.TypeLevel
+
+import qualified Data.Array as Array
+import qualified Data.Array.Base as BArray
+import GHC.Exts (Any)
+import Unsafe.Coerce
+
+-- | An array-backed extensible record with constant-time field
+-- access.
+newtype ARec (f :: k -> *) (ts :: [k]) = ARec (Array.Array Int Any)
+type role ARec representational nominal
+
+-- | Convert a 'Rec' into an 'ARec' for constant-time field access.
+toARec :: forall f ts. (NatToInt (RLength ts)) => Rec f ts -> ARec f ts
+toARec = go id
+  where go :: ([Any] -> [Any]) -> Rec f ts' -> ARec f ts
+        go acc RNil = ARec $! Array.listArray (0, n - 1) (acc [])
+        go acc (x :& xs) = go (acc . (unsafeCoerce x :)) xs
+        n = natToInt @(RLength ts)
+{-# INLINE toARec #-}
+
+-- | Defines a constraint that lets us index into an 'ARec' in order
+-- to produce a 'Rec' using 'fromARec'.
+class (NatToInt (RIndex t ts)) => IndexableField ts t where
+instance (NatToInt (RIndex t ts)) => IndexableField ts t where
+
+-- | Convert an 'ARec' into a 'Rec'.
+fromARec :: forall f ts.
+            (RecApplicative ts, RPureConstrained (IndexableField ts) ts)
+         => ARec f ts -> Rec f ts
+fromARec (ARec arr) = rpureConstrained @(IndexableField ts) aux
+  where aux :: forall t. NatToInt (RIndex t ts) => f t
+        aux = unsafeCoerce (arr Array.! natToInt @(RIndex t ts))
+{-# INLINE fromARec #-}
+
+-- | Get a field from an 'ARec'.
+aget :: forall t f ts. (NatToInt (RIndex t ts)) => ARec f ts -> f t
+aget (ARec arr) =
+  unsafeCoerce (BArray.unsafeAt arr (natToInt @(RIndex t ts)))
+{-# INLINE aget #-}
+
+-- | Set a field in an 'ARec'.
+aput :: forall t t' f ts ts'. (NatToInt (RIndex t ts))
+      => f t' -> ARec f ts -> ARec f ts'
+aput x (ARec arr) = ARec (arr Array.// [(i, unsafeCoerce x)])
+  where i = natToInt @(RIndex t ts)
+{-# INLINE aput #-}
+
+-- | Define a lens for a field of an 'ARec'.
+alens :: forall f g t t' ts ts'. (Functor g, NatToInt (RIndex t ts))
+      => (f t -> g (f t')) -> ARec f ts -> g (ARec f ts')
+alens f ar = fmap (flip (aput @t) ar) (f (aget ar))
+{-# INLINE alens #-}
+
+-- instance (i ~ RIndex t ts, i ~ RIndex t' ts', NatToInt (RIndex t ts)) => RecElem ARec t t' ts ts' i where
+--   rlens = alens
+--   rget = aget
+--   rput = aput
+
+instance RecElem ARec t t' (t ': ts) (t' ': ts) 'Z where
+  rlensC = alens
+  {-# INLINE rlensC #-}
+  rgetC = aget
+  {-# INLINE rgetC #-}
+  rputC = aput @t
+  {-# INLINE rputC #-}
+
+instance (RIndex t (s ': ts) ~ 'S i, NatToInt i,  RecElem ARec t t' ts ts' i)
+  => RecElem ARec t t' (s ': ts) (s ': ts') ('S i) where
+  rlensC = alens
+  {-# INLINE rlensC #-}
+  rgetC = aget
+  {-# INLINE rgetC #-}
+  rputC = aput @t
+  {-# INLINE rputC #-}
+
+-- | Get a subset of a record's fields.
+arecGetSubset :: forall rs ss f.
+                 (IndexWitnesses (RImage rs ss), NatToInt (RLength rs))
+              => ARec f ss -> ARec f rs
+arecGetSubset (ARec arr) = ARec (Array.listArray (0, n-1) $
+                                 go (indexWitnesses @(RImage rs ss)))
+  where go :: [Int] -> [Any]
+        go = map (arr Array.!)
+        n = natToInt @(RLength rs)
+{-# INLINE arecGetSubset #-}
+
+-- | Set a subset of a larger record's fields to all of the fields of
+-- a smaller record.
+arecSetSubset :: forall rs ss f. (IndexWitnesses (RImage rs ss))
+              => ARec f ss -> ARec f rs -> ARec f ss
+arecSetSubset (ARec arrBig) (ARec arrSmall) = ARec (arrBig Array.// updates)
+  where updates = zip (indexWitnesses @(RImage rs ss)) (Array.elems arrSmall)
+{-# INLINE arecSetSubset #-}
+
+instance (is ~ RImage rs ss, IndexWitnesses is, NatToInt (RLength rs))
+         => RecSubset ARec rs ss is where
+  rsubsetC f big = fmap (arecSetSubset big) (f (arecGetSubset big))
+  {-# INLINE rsubsetC #-}
+
+instance (RPureConstrained (IndexableField rs) rs,
+          RecApplicative rs,
+          Show (Rec f rs)) => Show (ARec f rs) where
+  show = show . fromARec
+
+instance (RPureConstrained (IndexableField rs) rs,
+          RecApplicative rs,
+          Eq (Rec f rs)) => Eq (ARec f rs) where
+  x == y = fromARec x == fromARec y
+
+instance (RPureConstrained (IndexableField rs) rs,
+          RecApplicative rs,
+          Ord (Rec f rs)) => Ord (ARec f rs) where
+  compare x y = compare (fromARec x) (fromARec y)

--- a/Data/Vinyl/TypeLevel.hs
+++ b/Data/Vinyl/TypeLevel.hs
@@ -21,12 +21,8 @@
 
 module Data.Vinyl.TypeLevel where
 
-#if __GLASGOW_HASKELL__ < 806
+import Data.Coerce
 import Data.Kind
-#else
-import GHC.Exts
-#endif
-import GHC.Types (Type)
 
 -- | A mere approximation of the natural numbers. And their image as lifted by
 -- @-XDataKinds@ corresponds to the actual natural numbers.
@@ -126,3 +122,8 @@ type family ApplyToField (t :: Type -> Type) (a :: k1) = (r :: k1) | r -> t a wh
 type family MapTyCon t xs = r | r -> xs where
   MapTyCon t '[] = '[]
   MapTyCon t (x ': xs) = ApplyToField t x ': MapTyCon t xs
+
+-- | This class is used for `consMatchCoercion` with older versions
+-- of GHC.
+class Coercible (f x) (g x) => Similar f g (x :: k)
+instance Coercible (f x) (g x) => Similar f g (x :: k)

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -1,6 +1,9 @@
 import Test.DocTest
 
 main :: IO ()
-main = doctest [ "tests/Intro.lhs"
+main = doctest [ "-package lens"
+               , "-package doctest"
+               , "-package singletons"
+               , "tests/Intro.lhs"
                , "Data/Vinyl/Functor.hs"
                , "Data/Vinyl/Curry.hs" ]

--- a/vinyl.cabal
+++ b/vinyl.cabal
@@ -42,6 +42,8 @@ library
   build-depends:       base >= 4.11 && <= 5,
                        ghc-prim,
                        array
+  if impl (ghc < 8.6.0)
+    build-depends: constraints >= 0.6.1
   default-language:    Haskell2010
   ghc-options:         -Wall
   other-extensions:    TypeApplications

--- a/vinyl.cabal
+++ b/vinyl.cabal
@@ -23,6 +23,7 @@ source-repository head
 library
   exposed-modules:     Data.Vinyl
                      , Data.Vinyl.ARec
+                     , Data.Vinyl.ARec.Internal
                      , Data.Vinyl.Class.Method
                      , Data.Vinyl.Core
                      , Data.Vinyl.CoRec


### PR DESCRIPTION
* The `ARec` newtype constructor was exposed by `Data.Vinyl.ARec`,
  making it easy to break type safety. Add a `Data.Vinyl.ARec.Internal`
  module and make `Data.Vinyl.ARec` export the type abstractly. Add
  a role annotation to prevent `coerce` from breaking the abstraction.

* Hack around doctests failing to compile. I don't know the "right"
  way to do this, but something seems better than nothing.