### PR TITLE
Add `NFData` instance

### DIFF
--- a/vinyl.cabal
+++ b/vinyl.cabal
@@ -41,6 +41,7 @@ library
                      , Data.Vinyl.XRec
   build-depends:       base >= 4.11 && <= 5,
                        ghc-prim,
+                       deepseq,
                        array
   if impl (ghc < 8.6.0)
     build-depends: constraints >= 0.6.1


### PR DESCRIPTION
I've recently had to add an `NFData` instance to `Rec` in a project, so I figured we could add it to the `Vinyl` library too. 

Since `deepseq` is a boot library, I suppose adding this new dependency shouldn't be a problem.