### PR TITLE
Don't export aput, alens from Data.Vinyl.ARec (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.14.0
+- Removed aput and alens from Data.Vinyl.ARec. They were used internally, but their type is unsound.
+
 # 0.13.1
 - GHC 9.0.1 support
 

--- a/Data/Vinyl/ARec.hs
+++ b/Data/Vinyl/ARec.hs
@@ -11,8 +11,6 @@ module Data.Vinyl.ARec
   , toARec
   , fromARec
   , aget
-  , aput
-  , alens
   , arecGetSubset
   , arecSetSubset
   , arecRepsMatchCoercion

--- a/Data/Vinyl/ARec/Internal.hs
+++ b/Data/Vinyl/ARec/Internal.hs
@@ -29,8 +29,8 @@ module Data.Vinyl.ARec.Internal
   , toARec
   , fromARec
   , aget
-  , aput
-  , alens
+  , unsafeAput
+  , unsafeAlens
   , arecGetSubset
   , arecSetSubset
   , arecRepsMatchCoercion
@@ -119,17 +119,17 @@ aget (ARec arr) =
 {-# INLINE aget #-}
 
 -- | Set a field in an 'ARec'.
-aput :: forall t t' f ts ts'. (NatToInt (RIndex t ts))
+unsafeAput :: forall t t' f ts ts'. (NatToInt (RIndex t ts))
       => f t' -> ARec f ts -> ARec f ts'
-aput x (ARec arr) = ARec (arr Array.// [(i, unsafeCoerce x)])
+unsafeAput x (ARec arr) = ARec (arr Array.// [(i, unsafeCoerce x)])
   where i = natToInt @(RIndex t ts)
-{-# INLINE aput #-}
+{-# INLINE unsafeAput #-}
 
 -- | Define a lens for a field of an 'ARec'.
-alens :: forall f g t t' ts ts'. (Functor g, NatToInt (RIndex t ts))
+unsafeAlens :: forall f g t t' ts ts'. (Functor g, NatToInt (RIndex t ts))
       => (f t -> g (f t')) -> ARec f ts -> g (ARec f ts')
-alens f ar = fmap (flip (aput @t) ar) (f (aget ar))
-{-# INLINE alens #-}
+unsafeAlens f ar = fmap (flip (unsafeAput @t) ar) (f (aget ar))
+{-# INLINE unsafeAlens #-}
 
 -- instance (i ~ RIndex t ts, i ~ RIndex t' ts', NatToInt (RIndex t ts)) => RecElem ARec t t' ts ts' i where
 --   rlens = alens
@@ -137,20 +137,20 @@ alens f ar = fmap (flip (aput @t) ar) (f (aget ar))
 --   rput = aput
 
 instance RecElem ARec t t' (t ': ts) (t' ': ts) 'Z where
-  rlensC = alens
+  rlensC = unsafeAlens
   {-# INLINE rlensC #-}
   rgetC = aget
   {-# INLINE rgetC #-}
-  rputC = aput @t
+  rputC = unsafeAput @t
   {-# INLINE rputC #-}
 
 instance (RIndex t (s ': ts) ~ 'S i, NatToInt i,  RecElem ARec t t' ts ts' i)
   => RecElem ARec t t' (s ': ts) (s ': ts') ('S i) where
-  rlensC = alens
+  rlensC = unsafeAlens
   {-# INLINE rlensC #-}
   rgetC = aget
   {-# INLINE rgetC #-}
-  rputC = aput @t
+  rputC = unsafeAput @t
   {-# INLINE rputC #-}
 
 -- | Get a subset of a record's fields.


### PR DESCRIPTION
Their types are under-constrained 
* Renames `aput` and `alens` to `unsafeAput` and `unsafeAlens` respectively to warn potential users of under-constrained type 
* Removes them from the export list of Data.Vinyl.ARec 

`aget` seems to be fine, but maybe it should also be removed from the export list, since it is available as `rgetC`?
