### PR TITLE
fix typos

### DIFF
--- a/Data/Vinyl/ARec/Internal.hs
+++ b/Data/Vinyl/ARec/Internal.hs
@@ -27,8 +27,8 @@
 --
 -- Tradeoffs:
 --
--- * No sharing of the spine (i.e. when you change elements in the front of the
---   record the tail can't be re-used)
+-- * No sharing of the spine (i.e., when you change elements in the front of
+--   the record the tail can't be re-used)
 -- * ARec requires (4 + n) words + size of the fields
 --   * 1 for the ARec constructor
 --   * 1 for the pointer to the SmallArray#

--- a/Data/Vinyl/ARec/Internal/SmallArray.hs
+++ b/Data/Vinyl/ARec/Internal/SmallArray.hs
@@ -8,7 +8,7 @@
 -- This module exposes _unsafe_ functions to work with SmallArrays.  That means
 -- that specifically neither index bounds nor element types are checked So this
 -- functionality should only be used in a context that enforces them by some
--- other means, e.g. ARec's type index
+-- other means, e.g., ARec's type index
 
 module Data.Vinyl.ARec.Internal.SmallArray where
 

--- a/Data/Vinyl/CoRec.hs
+++ b/Data/Vinyl/CoRec.hs
@@ -152,7 +152,7 @@ lastField v@(x :& _) = coRecTraverse getCompose $ foldRec aux (CoRec x) v
         aux c _ = c
 
 -- | Apply methods from a type class to a 'CoRec'. Intended for use
--- with @TypeApplications@, e.g. @onCoRec \@Show show r@
+-- with @TypeApplications@, e.g., @onCoRec \@Show show r@
 onCoRec :: forall c f ts b g. (RPureConstrained c ts)
         => (forall a. (a ∈ ts, c a) => f a -> g b)
         -> CoRec f ts -> g b
@@ -161,7 +161,7 @@ onCoRec f (CoRec x) = case getDict @c @ts x of
 {-# INLINE onCoRec #-}
 
 -- | Apply a type class method to a 'Field'. Intended for use with
--- @TypeApplications@, e.g. @onField \@Show show r@.
+-- @TypeApplications@, e.g., @onField \@Show show r@.
 onField :: forall c ts b. (RPureConstrained c ts)
         => (forall a. (a ∈ ts, c a) => a -> b)
         -> Field ts -> b

--- a/Data/Vinyl/Core.hs
+++ b/Data/Vinyl/Core.hs
@@ -103,7 +103,7 @@ rappend (x :& xs) ys = x :& (xs `rappend` ys)
 
 -- | Combine two records by combining their fields using the given
 -- function. The first argument is a binary operation for combining
--- two values (e.g. '(<>)'), the second argument takes a record field
+-- two values (e.g., '(<>)'), the second argument takes a record field
 -- into the type equipped with the desired operation, the third
 -- argument takes the combined value back to a result type.
 rcombine :: (RMap rs, RApply rs)

--- a/Data/Vinyl/Derived.hs
+++ b/Data/Vinyl/Derived.hs
@@ -184,7 +184,7 @@ rmapf :: AllFields fs
       -> Rec f fs -> Rec g fs
 rmapf f = (rpureConstrained @KnownField (Lift f) <<*>>)
 
--- | Remove the first component (e.g. the label) from a type-level
+-- | Remove the first component (e.g., the label) from a type-level
 -- list of pairs.
 type family Unlabeled ts where
   Unlabeled '[] = '[]

--- a/Data/Vinyl/FromTuple.hs
+++ b/Data/Vinyl/FromTuple.hs
@@ -29,7 +29,7 @@ import GHC.TypeLits (TypeError, ErrorMessage(Text))
 -- | Convert a tuple of types formed by the application of a common
 -- type constructor to a tuple of the common type constructor and a
 -- list of the types to which it is applied in the original
--- tuple. E.g. @TupleToRecArgs f (f a, f b) ~ (f, [a,b])@.
+-- tuple, e.g., @TupleToRecArgs f (f a, f b) ~ (f, [a,b])@.
 type family TupleToRecArgs f t = (r :: (u -> Type, [u])) | r -> t where
   TupleToRecArgs f (f a, f b, f c, f d, f e, f z, f g, f h) =
     '(f, [a,b,c,d,e,z,g,h])

--- a/Data/Vinyl/SRec.hs
+++ b/Data/Vinyl/SRec.hs
@@ -1,5 +1,5 @@
 -- | 'Storable' records offer an efficient flat, packed representation
--- in memory. In particular, field access is constant time (i.e. it
+-- in memory. In particular, field access is constant time (i.e., it
 -- doesn't depend on where in the record the field is) and as fast as
 -- possible, but updating fields may not be as efficient. The
 -- requirement is that all fields of a record have 'Storable'
@@ -16,7 +16,7 @@
 -- records here takes two functor arguments: they will usually be the
 -- same; we fix one when writing instances and write instance contexts
 -- that reference that type, and then require that the methods
--- (e.g. 'rget') are called on records whose functor argument is equal
+-- (e.g., 'rget') are called on records whose functor argument is equal
 -- to the one we picked. For usability, we provide an 'SRec' type
 -- whose lens API is fixed to 'ElField' as the functor. Other
 -- specializations are possible, and the work of those instances can
@@ -265,7 +265,7 @@ slens f sr = fmap (flip sput sr) (f (sget sr))
 -- 'SRec2' a phantom tag that duplicates the "real" functor parameter,
 -- and define a constraint that the real argument is in fact
 -- 'ElField'. This lets us write instances for different applications
--- of @SRec2@ (e.g. instance for @SRec2 Foo@ for records of type
+-- of @SRec2@ (e.g., instance for @SRec2 Foo@ for records of type
 -- @SRec2 Foo Foo ts@, and an instance for @SRec2 Bar@ for records of
 -- type @SRec2 Bar Bar ts@).
 

--- a/Data/Vinyl/Syntax.hs
+++ b/Data/Vinyl/Syntax.hs
@@ -6,7 +6,7 @@
 -- | Concise vinyl record field lens syntax. This module exports an
 -- orphan instance to make working with labels a bit more powerful. It
 -- will conflict with other libraries that provide special syntax for
--- labels (i.e. placing a label in function application position, as
+-- labels (i.e., placing a label in function application position, as
 -- in @#age 23@, or using a label as a lens).
 --
 -- Example:

--- a/Data/Vinyl/TypeLevel.hs
+++ b/Data/Vinyl/TypeLevel.hs
@@ -73,7 +73,7 @@ type family RImage (rs :: [k]) (ss :: [k]) :: [Nat] where
   RImage '[] ss = '[]
   RImage (r ': rs) ss = RIndex r ss ': RImage rs ss
 
--- | Remove the first occurence of a type from a type-level list.
+-- | Remove the first occurrence of a type from a type-level list.
 type family RDelete r rs where
   RDelete r (r ': rs) = rs
   RDelete r (s ': rs) = s ': RDelete r rs

--- a/tests/Aeson.hs
+++ b/tests/Aeson.hs
@@ -14,7 +14,7 @@
 -- by inspecting the JSON serialization of each field, and extracting
 -- it as a key-value pair if it was serialized as a JSON object with a
 -- single named field. This works, but means that the types do not
--- guarantee correctness (i.e. if a record field is serialized as a
+-- guarantee correctness (i.e., if a record field is serialized as a
 -- 'Number', we won't be able to include it in the serialization of
 -- the 'Rec').
 --


### PR DESCRIPTION
Data/Vinyl/ARec/Internal.hs
Data/Vinyl/ARec/Internal/SmallArray.hs
Data/Vinyl/CoRec.hs
Data/Vinyl/Core.hs
Data/Vinyl/Derived.hs
Data/Vinyl/FromTuple.hs
Data/Vinyl/SRec.hs
Data/Vinyl/Syntax.hs
Data/Vinyl/TypeLevel.hs
tests/Aeson.hs

maybe retaining `E.g.` at the beginning of a new sentence would be preferred

```diff
- -- tuple. E.g. @TupleToRecArgs f (f a, f b) ~ (f, [a,b])@.
+ -- tuple, e.g., @TupleToRecArgs f (f a, f b) ~ (f, [a,b])@.
```