### PR TITLE
Drop superfluous constraints

### DIFF
--- a/Data/Vinyl/Derived.hs
+++ b/Data/Vinyl/Derived.hs
@@ -57,7 +57,7 @@ fieldMap f (Field x) = Field (f x)
 
 -- | Something in the spirit of 'traverse' for 'ElField' whose kind
 -- fights the standard library.
-traverseField :: (KnownSymbol s, Functor f)
+traverseField :: Functor f
               => (a -> b) -> f (ElField '(s,a)) -> ElField '(s, f b)
 traverseField f t = Field (fmap (f . getField)  t)
 
@@ -71,7 +71,7 @@ infix 8 =:
 -- | Operator for creating an 'ElField'. With the @-XOverloadedLabels@
 -- extension, this permits usage such as, @#foo =: 23@ to produce a
 -- value of type @ElField ("foo" ::: Int)@.
-(=:) :: KnownSymbol l => Label (l :: Symbol) -> (v :: *) -> ElField (l ::: v)
+(=:) :: Label (l :: Symbol) -> (v :: *) -> ElField (l ::: v)
 _ =: v = Field v
 
 -- | Get a named field from a record.
@@ -90,14 +90,14 @@ rvalf x = getField . rgetf x
 -- | Set a named field. @rputf' #foo 23@ sets the field named @#foo@ to
 -- @23@.
 rputf' :: forall l v v' record us us'.
-          (HasField record l us us' v v', KnownSymbol l, RecElemFCtx record ElField)
+          (HasField record l us us' v v', RecElemFCtx record ElField)
        => Label l -> v' -> record ElField us -> record ElField us'
 rputf' _ = rput' @_ @(l:::v) . (Field :: v' -> ElField '(l,v'))
 
 -- | Set a named field without changing its type. @rputf #foo 23@ sets
 -- the field named @#foo@ to @23@.
 rputf :: forall l v record us.
-          (HasField record l us us v v, KnownSymbol l, RecElemFCtx record ElField)
+          (HasField record l us us v v, RecElemFCtx record ElField)
        => Label l -> v -> record ElField us -> record ElField us
 rputf _ = rput @_ @(l:::v) . Field
 
@@ -134,7 +134,7 @@ rlensf :: forall l v record g us.
 rlensf _ f = rlens @(l ::: v) (rfield f)
 
 -- | Shorthand for a 'FieldRec' with a single field.
-(=:=) :: KnownSymbol s => Label (s :: Symbol) -> a -> FieldRec '[ '(s,a) ]
+(=:=) :: Label (s :: Symbol) -> a -> FieldRec '[ '(s,a) ]
 (=:=) _ x = Field x :& RNil
 
 -- | A proxy for field types.
@@ -204,7 +204,7 @@ instance StripFieldNames '[] where
   withNames RNil = RNil
   withNames' RNil = RNil
 
-instance (KnownSymbol s, StripFieldNames ts) => StripFieldNames ('(s,t) ': ts) where
+instance StripFieldNames ts => StripFieldNames ('(s,t) ': ts) where
   stripNames (Field x :& xs) = pure x :& stripNames xs
   stripNames' (Compose x :& xs) = fmap getField x :& stripNames' xs
   withNames (Identity x :& xs) = Field x :& withNames xs

--- a/Data/Vinyl/Functor.hs
+++ b/Data/Vinyl/Functor.hs
@@ -116,12 +116,12 @@ newtype ElField (t :: (Symbol, Type)) = Field (Snd t)
 deriving instance Eq t => Eq (ElField '(s,t))
 deriving instance Ord t => Ord (ElField '(s,t))
 
-instance KnownSymbol s => Generic (ElField '(s,a)) where
+instance Generic (ElField '(s,a)) where
   type Rep (ElField '(s,a)) = C1 ('MetaCons s 'PrefixI 'False) (Rec0 a)
   from (Field x) = M1 (K1 x)
   to (M1 (K1 x)) = Field x
 
-instance (Num t, KnownSymbol s) => Num (ElField '(s,t)) where
+instance Num t => Num (ElField '(s,t)) where
   Field x + Field y = Field (x+y)
   Field x * Field y = Field (x*y)
   abs (Field x) = Field (abs x)
@@ -132,18 +132,18 @@ instance (Num t, KnownSymbol s) => Num (ElField '(s,t)) where
 instance Semigroup t => Semigroup (ElField '(s,t)) where
   Field x <> Field y = Field (x <> y)
 
-instance (KnownSymbol s, Monoid t) => Monoid (ElField '(s,t)) where
+instance Monoid t => Monoid (ElField '(s,t)) where
   mempty = Field mempty
   mappend (Field x) (Field y) = Field (mappend x y)
 
-instance (Real t, KnownSymbol s) => Real (ElField '(s,t)) where
+instance Real t => Real (ElField '(s,t)) where
   toRational (Field x) = toRational x
 
-instance (Fractional t, KnownSymbol s) => Fractional (ElField '(s,t)) where
+instance Fractional t => Fractional (ElField '(s,t)) where
   fromRational = Field . fromRational
   Field x / Field y = Field (x / y)
 
-instance (Floating t, KnownSymbol s) => Floating (ElField '(s,t)) where
+instance Floating t => Floating (ElField '(s,t)) where
   pi = Field pi
   exp (Field x) = Field (exp x)
   log (Field x) = Field (log x)
@@ -158,13 +158,13 @@ instance (Floating t, KnownSymbol s) => Floating (ElField '(s,t)) where
   acosh (Field x) = Field (acosh x)
   atanh (Field x) = Field (atanh x)
 
-instance (RealFrac t, KnownSymbol s) => RealFrac (ElField '(s,t)) where
+instance RealFrac t => RealFrac (ElField '(s,t)) where
   properFraction (Field x) = fmap Field (properFraction x)
 
 instance (Show t, KnownSymbol s) => Show (ElField '(s,t)) where
   show (Field x) = symbolVal (Proxy::Proxy s) ++" :-> "++show x
 
-instance forall s t. (KnownSymbol s, Storable t)
+instance forall s t. Storable t
     => Storable (ElField '(s,t)) where
   sizeOf _ = sizeOf (undefined::t)
   alignment _ = alignment (undefined::t)

--- a/Data/Vinyl/XRec.hs
+++ b/Data/Vinyl/XRec.hs
@@ -32,7 +32,6 @@ import Data.Vinyl.Functor
 import Data.Vinyl.Lens (RecElem, RecElemFCtx, rgetC)
 import Data.Vinyl.TypeLevel (RIndex)
 import Data.Monoid
-import GHC.TypeLits (KnownSymbol)
 
 type XRec f = Rec (XData f)
 pattern (::&) :: HKD f r -> XRec f rs -> XRec f (r ': rs)
@@ -146,7 +145,7 @@ instance IsoHKD Identity a where
 
 -- | Work with values of type 'ElField' @'(s,a)@ as if they were of
 -- type @a@.
-instance KnownSymbol s => IsoHKD ElField '(s,a) where
+instance IsoHKD ElField '(s,a) where
   type HKD ElField '(s,a) = a
   unHKD = Field
   toHKD (Field x) = x


### PR DESCRIPTION
`KnownSymbol` is no longer needed in many cases after cf0558ee372ceea42c95231c7de1745fce2e3dc7.