### PR TITLE
Add a fixity declaration for ++

### DIFF
--- a/Data/Vinyl/TypeLevel.hs
+++ b/Data/Vinyl/TypeLevel.hs
@@ -83,6 +83,8 @@ type family RecAll (f :: u -> *) (rs :: [u]) (c :: * -> Constraint) :: Constrain
   RecAll f '[] c = ()
   RecAll f (r ': rs) c = (c (f r), RecAll f rs c)
 
+infixr 5 ++
+
 -- | Append for type-level lists.
 type family (as :: [k]) ++ (bs :: [k]) :: [k] where
   '[] ++ bs = bs


### PR DESCRIPTION
The fixity of the type-level `++` should match that of the term-level one, so people can write things like `as ++ b ': cs` without parentheses.

This is theoretically a breaking change, but I don't think that should stop it.