### PR TITLE
Document a design choice for Head and Tail

### DIFF
--- a/Data/Vinyl/Core.hs
+++ b/Data/Vinyl/Core.hs
@@ -415,8 +415,19 @@ instance ReifyConstraint NFData f xs => NFData (Rec f xs) where
       go RNil = ()
       go (Compose (Dict x) :& xs) = rnf x `seq` go xs
 
+-- | Analogous to 'Data.List.head'. Unlike the version in @singletons@,
+-- this family merely gets stuck instead of producing a type error if
+-- the list is empty. This is often better, because the type error that
+-- would be produced here would be much less informative than one that
+-- would likely be available where it's used.
 type family Head xs where
   Head (x ': _) = x
+  
+-- | Analogous to 'Data.List.tail'. Unlike the version in @singletons@,
+-- this family merely gets stuck instead of producing a type error if
+-- the list is empty. This is often better, because the type error that
+-- would be produced here would be much less informative than one that
+-- would likely be available where it's used.
 type family Tail xs where
   Tail (_ ': xs) = xs
 


### PR DESCRIPTION
I'm starting to use these type families at work, and would prefer that the error behavior remain the same. If it's not going to, I'd like to know that sooner rather than later.